### PR TITLE
sync jwt and save in database

### DIFF
--- a/src/main/scala/kanban/auth/ProjectUcanService.scala
+++ b/src/main/scala/kanban/auth/ProjectUcanService.scala
@@ -84,7 +84,11 @@ object ProjectUcanService {
 
             }
             val payload = builderWithProof.build()
-            Ucan.sign(payload, issuerKm).flatMap(UcanTokenStore.save)
+            // Return full JWT instead of CID
+            Ucan.sign(payload, issuerKm).flatMap { ucan =>
+              val jwt = Ucan.encodeJwt(ucan)
+              UcanTokenStore.save(ucan).map(_ => jwt)
+            }
           }
       }
     }

--- a/src/main/scala/kanban/controllers/ProjectController.scala
+++ b/src/main/scala/kanban/controllers/ProjectController.scala
@@ -27,6 +27,7 @@ import kanban.sync.Replica.replicaDBEntry
 import scala.scalajs.js
 import kanban.ui.views.GlobalState
 import kanban.sync.TokenSync
+import kanban.service.UcanTokenStore
 
 object ProjectController {
   val projects: Var[List[Project]] = Var(List.empty)
@@ -100,9 +101,18 @@ object ProjectController {
     }
   }
 
-  // --- Minimal Token receive callback, only the message ---
+  // Receive Tokens
   TokenSync.receiveToken { (projectId, userId, token) =>
     println(s"[ProjectController] Received UCAN token for project $projectId from user $userId: $token")
+
+    // save tokens in the database after syncing
+    UcanTokenStore.saveJwt(token).onComplete {
+      case Success(cid) =>
+        println(s"[ProjectController] Stored UCAN JWT locally. CID = $cid")
+
+      case Failure(ex) =>
+        println(s"[ProjectController] Failed to store UCAN token: ${ex.getMessage}")
+    }
   }
 
   // listen for updates from other peers

--- a/src/main/scala/kanban/ui/views/ProjectDetailsPageView.scala
+++ b/src/main/scala/kanban/ui/views/ProjectDetailsPageView.scala
@@ -428,7 +428,7 @@ object ProjectDetailsPageView {
               println(
                 s"UCAN token created for ${user.name.read} ($permission): $token"
               )
-              // Minimal message broadcast token to other peers
+              // Broadcast token to other peers
               TokenSync.sendToken(
                 projectId = projectId.delegate,
                 userId    = user.id.delegate,


### PR DESCRIPTION
Modify delegate to DID function to return JWT not CID anymore and then save it into the database after syncing. Whether we should broadcast the JWT or only CID is not clear.